### PR TITLE
[T15219] Fix issues reported against live API

### DIFF
--- a/account_mtd/__openerp__.py
+++ b/account_mtd/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'UK HMRC MTD - Connector',
-    'version': '0.9',
+    'version': '0.10',
     'author': 'OpusVL',
     'website': 'http://opusvl.com/',
     'summary': '',

--- a/account_mtd/__openerp__.py
+++ b/account_mtd/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'UK HMRC MTD - Connector',
-    'version': '0.5',
+    'version': '0.9',
     'author': 'OpusVL',
     'website': 'http://opusvl.com/',
     'summary': '',

--- a/account_mtd/controllers/main.py
+++ b/account_mtd/controllers/main.py
@@ -41,7 +41,7 @@ class Authorize(http.Controller):
                     {menu_path} to try again.
                 </p>
             """
-            menu_path = self.env.ref('account_mtd.mtd_menu').display_name
+            menu_path = http.request.env.ref('account_mtd.mtd_menu').display_name
             # TODO add a link back to Accounting menu???
             #  could be even more accurate if all the api_trackers happened
             #  to be from the same place (which we likely can record)

--- a/account_mtd/controllers/main.py
+++ b/account_mtd/controllers/main.py
@@ -24,13 +24,32 @@ class Authorize(http.Controller):
                 "\nWe can have more than one if there was a request sent, and authorisation it was never completed." +
                 "\nIf in this state we need to reset the tracker and get user to create a new connection " +
                 "\napi_tracer = {}".format(api_trackers))
-            for record in api_trackers:
-                record.closed = 'more_than_one'
-            return werkzeug.utils.redirect('/web')
-            raise exceptions.Warning(
-                "No connection request made Please try to connect again!"
+            api_trackers.unlink()
+            situation_html = (
+                "No active authentication request found in Odoo."
+                if len(api_trackers) == 0
+                else """
+                    More than one active authentication request in progress.
+                    They have been cleared from Odoo but you will need
+                    to start again.
+                """
             )
-            # This should then return to the home page
+            message_html_template = """
+                <p><strong>{situation_html}</strong></p>
+                <p>
+                    Please return to the screen you were on within
+                    {menu_path} to try again.
+                </p>
+            """
+            menu_path = self.env.ref('account_mtd.mtd_menu').display_name
+            # TODO add a link back to Accounting menu???
+            #  could be even more accurate if all the api_trackers happened
+            #  to be from the same place (which we likely can record)
+            message_html = message_html_template.format(
+                situation_html=situation_html,
+                menu_path=menu_path,
+            )
+            return message_html
         else:
 
             # search for the method which we need to invoke to get to exchange the authorisation code with access token

--- a/account_mtd/doc/clear_token_tables.sql
+++ b/account_mtd/doc/clear_token_tables.sql
@@ -1,0 +1,12 @@
+-- Sometimes it's necessary to change the VAT number, user and password for sign-in to the API
+-- This is particularly the case when developing (lets hope it's not the case for users)
+-- When you do this you need to clear the cached auth data.
+-- It would be better if we stored the VAT number against that auth data
+-- and used that in searches so it automatically ignores dead auth data.
+-- But for now, please run this SQL script when you need to do this during development.
+
+-- e.g. docker-compose exec -T -u root postgresql psql -U odoo DBNAME < account_mtd/clear_token_tables.sql
+
+delete from mtd_api_tokens;
+
+delete from mtd_api_request_tracker;

--- a/account_mtd/doc/testing_auth_redirect_endpoint.md
+++ b/account_mtd/doc/testing_auth_redirect_endpoint.md
@@ -1,0 +1,67 @@
+# Testing /auth-redirect
+
+## Case where no trackers are there
+
+Use the sandbox.
+
+Run SQL:
+
+```sql
+DELETE FROM mtd_api_request_tracker;
+```
+
+When logged into the same Odoo database through web UI, visit (assuming running locally on port 8069):
+
+http://localhost:8069/auth-redirect?code=42
+
+Expected outcome:
+* You should see an error message telling you there is no active token.
+* There should be instructions for how to get back to a point where the user can try again.
+
+## Case where there are more than one tracker
+
+Use the sandbox.
+
+Run SQL:
+
+```sql
+DELETE FROM mtd_api_request_tracker;
+delete from mtd_api_tokens;
+```
+
+Find a page where you can submit something to HMRC, e.g.
+Retrieve VAT Periods (in account_mtd_vat), with a brand new test VAT number in the sandbox,
+and click the action button.
+
+This should redirect you onto HMRC's site.  Don't proceed or log in yet!
+
+Follow this example for how to duplicate the tracker record in the database:
+
+```
+mtd-vat=# select * from mtd_api_request_tracker;
+ id | menu_id | create_uid | request_sent | endpoint_id | api_id | write_uid |        create_date         | closed |      module_name      | action | user_id |         write_date         | company_id 
+----+---------+------------+--------------+-------------+--------+-----------+----------------------------+--------+-----------------------+--------+---------+----------------------------+------------
+ 79 | 247     |          1 | t            | 1           |      2 |         1 | 2019-06-21 12:11:14.896257 |        | mtd_vat.vat_endpoints | 289    |       1 | 2019-06-21 12:11:14.896257 | 1
+(1 row)
+
+mtd-vat=# insert into mtd_api_request_tracker (menu_id,  create_uid, request_sent,  endpoint_id,  api_id,  write_uid, closed, module_name, action, user_id,  company_id) values (247, 1, true, 1, 2, 1, NULL, 'mtd_vat.vat_endpoints', 289, 1, 1);
+INSERT 0 1
+
+mtd-vat=# select * from mtd_api_request_tracker;
+ id | menu_id | create_uid | request_sent | endpoint_id | api_id | write_uid |        create_date         | closed |      module_name      | action | user_id |         write_date         | company_id 
+----+---------+------------+--------------+-------------+--------+-----------+----------------------------+--------+-----------------------+--------+---------+----------------------------+------------
+ 79 | 247     |          1 | t            | 1           |      2 |         1 | 2019-06-21 12:11:14.896257 |        | mtd_vat.vat_endpoints | 289    |       1 | 2019-06-21 12:11:14.896257 | 1
+ 80 | 247     |          1 | t            | 1           |      2 |         1 |                            |        | mtd_vat.vat_endpoints | 289    |       1 |                            | 1
+(2 rows)
+
+```
+
+
+Now continue through the HMRC's authentication process in the browser.
+
+
+Expected outcome:
+* When you've authorised the app, you should be redirected back to an error message page.
+* The message should tell you that more than one authentication request was in progress.
+* Check that the instructions given to you can take you back to the point where you can try again,
+  and that trying again (without other users attempting to do an auth at the same time) works this time.

--- a/account_mtd_vat/__openerp__.py
+++ b/account_mtd_vat/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'UK HMRC MTD - VAT',
-    'version': '0.9',
+    'version': '0.10',
     'author': 'OpusVL',
     'website': 'http://opusvl.com/',
     'summary': '',

--- a/account_mtd_vat/__openerp__.py
+++ b/account_mtd_vat/__openerp__.py
@@ -23,7 +23,7 @@
 
 {
     'name': 'UK HMRC MTD - VAT',
-    'version': '0.8',
+    'version': '0.9',
     'author': 'OpusVL',
     'website': 'http://opusvl.com/',
     'summary': '',

--- a/account_mtd_vat/__openerp__.py
+++ b/account_mtd_vat/__openerp__.py
@@ -28,7 +28,7 @@
     'website': 'http://opusvl.com/',
     'summary': '',
     'category': '',
-    'description': 'Making Tax Digital for VAT - 08.0',
+    'description': 'Making Tax Digital for VAT - 8.0',
     'images': [
     ],
     'depends': [

--- a/account_mtd_vat/models/mtd_vat_endpoint.py
+++ b/account_mtd_vat/models/mtd_vat_endpoint.py
@@ -414,7 +414,21 @@ class MtdVATEndpoints(models.Model):
 
         return self.process_connection()
 
+    def _obligation_fulfilled(self):
+        # TODO resync with HMRC first
+        return self.select_vat_obligation.is_fulfilled()
+
+    def _we_think_we_have_previously_submitted_successfully(self):
+        # Because HMRC, at least on the sandbox, doesn't return back the
+        # right obligation status on the obligations endpoint after submitting.
+        return self.select_vat_obligation.have_sent_submission_successfully
+
     def _handle_vat_submit_returns_endpoint(self):
+        if self._obligation_fulfilled() \
+                or self._we_think_we_have_previously_submitted_successfully():
+            raise exceptions.Warning(
+                "VAT return has already been submitted for this obligation."
+            )
         # Check to see if we have HMRC Posting record We can not submit VAT witout a
         # HMRC posting template for the company
         hmrc_posting_config = self.env['mtd_vat.hmrc_posting_configuration'].search([

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -439,7 +439,7 @@ class MtdVatIssueRequest(models.Model):
         record.total_value_goods_supplied = response_logs['totalValueGoodsSuppliedExVAT']
         record.total_acquisitions = response_logs['totalAcquisitionsExVAT']
 
-    def build_submit_vat_params(self, record=None):
+    def build_submit_vat_params(self, record):
         params = {
         "periodKey": urllib.quote_plus(record.period_key_submit),
         "vatDueSales": record.vat_due_sales_submit,

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -265,9 +265,7 @@ class MtdVatIssueRequest(models.Model):
 
     def create_submission_log_entry(self, response_text, record):
 
-        submission_logs = self.env['mtd_vat.vat_submission_logs']
-
-        return submission_logs.create({
+        return self.env['mtd_vat.vat_submission_logs'].create({
             'name': "{} - {}".format(record.date_from, record.date_to),
             'response_text': response_text,
             'start': record.date_from,

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -426,7 +426,6 @@ class MtdVatIssueRequest(models.Model):
 
 
     def display_view_returns(self, response, record):
-
         response_logs = json.loads(response.text)
         record.period_key = response_logs['periodKey']
         record.vat_due_sales = response_logs['vatDueSales']

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -263,6 +263,7 @@ class MtdVatIssueRequest(models.Model):
             date=current_time.date(),
         )
 
+    @api.model
     def create_submission_log_entry(self, response_text, record):
         return self.env['mtd_vat.vat_submission_logs'].create({
             'name': "{} - {}".format(record.date_from, record.date_to),

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -438,20 +438,19 @@ class MtdVatIssueRequest(models.Model):
         record.total_acquisitions = response_logs['totalAcquisitionsExVAT']
 
     def build_submit_vat_params(self, record):
-        params = {
-        "periodKey": urllib.quote_plus(record.period_key_submit),
-        "vatDueSales": record.vat_due_sales_submit,
-        "vatDueAcquisitions": record.vat_due_acquisitions_submit,
-        "totalVatDue": record.total_vat_due_submit,
-        "vatReclaimedCurrPeriod": record.vat_reclaimed_submit,
-        "netVatDue": abs(record.net_vat_due_submit),
-        "totalValueSalesExVAT": record.total_value_sales_submit,
-        "totalValuePurchasesExVAT": record.total_value_purchase_submit,
-        "totalValueGoodsSuppliedExVAT": record.total_value_goods_supplied_submit,
-        "totalAcquisitionsExVAT": record.total_acquisitions_submit,
-        "finalised": record.finalise
+        return {
+            "periodKey": urllib.quote_plus(record.period_key_submit),
+            "vatDueSales": record.vat_due_sales_submit,
+            "vatDueAcquisitions": record.vat_due_acquisitions_submit,
+            "totalVatDue": record.total_vat_due_submit,
+            "vatReclaimedCurrPeriod": record.vat_reclaimed_submit,
+            "netVatDue": abs(record.net_vat_due_submit),
+            "totalValueSalesExVAT": record.total_value_sales_submit,
+            "totalValuePurchasesExVAT": record.total_value_purchase_submit,
+            "totalValueGoodsSuppliedExVAT": record.total_value_goods_supplied_submit,
+            "totalAcquisitionsExVAT": record.total_acquisitions_submit,
+            "finalised": record.finalise
         }
-        return params
 
     def get_hash_object_for_submission(self, unique_number, company_id):
 

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -424,7 +424,6 @@ class MtdVatIssueRequest(models.Model):
                 'vrn': record.vrn
             })
 
-
     def display_view_returns(self, response, record):
         response_logs = json.loads(response.text)
         record.period_key = response_logs['periodKey']

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -59,7 +59,9 @@ class MtdVatIssueRequest(models.Model):
     @api.multi
     def json_command(self, command, module_name=None, record_id=None, api_tracker=None, timeout=3):
         try:
-
+            # TODO take record (with more descriptive name) as param instead
+            #  of module_name and record_id.  Also we can't do anything without
+            #  it so no point making the parameter optional
             record = self.env[module_name].search([('id', '=', record_id)])
             _logger.info(
                 "json_command - we need to find the record and assign it to self"

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -267,7 +267,7 @@ class MtdVatIssueRequest(models.Model):
 
         submission_logs = self.env['mtd_vat.vat_submission_logs']
 
-        submission_log = submission_logs.create({
+        return submission_logs.create({
             'name': "{} - {}".format(record.date_from, record.date_to),
             'response_text': response_text,
             'start': record.date_from,
@@ -286,7 +286,6 @@ class MtdVatIssueRequest(models.Model):
             'company_id': record.company_id.id,
             'redirect_url': record.hmrc_configuration.redirect_url
         })
-        return submission_log
 
     def copy_account_move_lines_to_storage(self, record, unique_number, submission_log):
 

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -237,8 +237,8 @@ class MtdVatIssueRequest(models.Model):
         record.response_from_hmrc = success_message
 
     def add_submit_vat_returns(self, response=None, record=None):
-
         response_logs = json.loads(response.text)
+        submission_log = self.create_submission_log_entry(response.text, record)
         record.response_from_hmrc = self._success_message(
             submission_log_entry=submission_log,
             current_time=datetime.now(),

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -162,6 +162,7 @@ class MtdVatIssueRequest(models.Model):
                 self.display_view_returns(response, record)
             elif record.endpoint_name == "submit-vat-returns":
                 record.submit_vat_flag=True
+                self.notify_submit_vat_returns_success(endpoint_record=record)
                 self.add_submit_vat_returns(response, record)
             return self.process_successful_response(record, api_tracker)
 
@@ -236,9 +237,16 @@ class MtdVatIssueRequest(models.Model):
         )
         record.response_from_hmrc = success_message
 
+    def notify_submit_vat_returns_success(self, endpoint_record):
+        endpoint_record.select_vat_obligation\
+            .have_sent_submission_successfully = True
+        self.env.cr.commit()   # Make sure crash later doesn't lose this status
+
     def add_submit_vat_returns(self, response=None, record=None):
         response_logs = json.loads(response.text)
         submission_log = self.create_submission_log_entry(response.text, record)
+        # Make sure crash later doesn't wipe out the submission log entry
+        self.env.cr.commit()
         record.response_from_hmrc = self._success_message(
             submission_log_entry=submission_log,
             current_time=datetime.now(),

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import requests
+import textwrap
 import json
 import logging
 import werkzeug
@@ -235,31 +236,32 @@ class MtdVatIssueRequest(models.Model):
     def add_submit_vat_returns(self, response=None, record=None):
 
         response_logs = json.loads(response.text)
-
-        # TODO this logic is replicated - use value from created submission_log
-        #  instead
-        charge_Ref_Number="No Data Found"
-        if 'chargeRefNumber' in response_logs.keys():
-            charge_Ref_Number=response_logs['chargeRefNumber']
-
-        submission_log = self.create_submission_log_entry(response.text, record)
-
-        # TODO this logic is replicated - use values from created submission_log
-        #  instead
-        success_message = (
-                "Date {date}     Time {time} \n".format(date=datetime.now().date(),
-                                                        time=datetime.now().time())
-                + "\nCongratulations ! The submission has been made successfully to HMRC. \n\n"
-                + "Period: {}\n".format(record.date_from, record.date_to)
-                + "Unique number: {}\n".format(response_logs['formBundleNumber'])
-                + "Payment indicator: {}\n".format(response_logs['paymentIndicator'])
-                + "Charge ref number: {}\n".format(charge_Ref_Number)
-                + "Processing date: {}\n\n".format(response_logs['processingDate'])
-                + "Please check the submission logs for details."
+        record.response_from_hmrc = self._success_message(
+            submission_log_entry=submission_log,
+            current_time=datetime.now(),
         )
-        record.response_from_hmrc = success_message
-
         self.copy_account_move_lines_to_storage(record, response_logs['formBundleNumber'], submission_log)
+
+    @api.model
+    def _success_message(self, submission_log_entry, current_time):
+        template = """
+            Date {date}     Time {time}
+            
+            Congratulations ! The submission has been made successfully to HMRC.
+            
+            Period: {log.start} - {log.end}
+            Unique number: {log.unique_number}
+            Payment indicator: {log.payment_indicator}
+            Charge ref number: {log.charge_ref_number}
+            Processing date: {log.raw_processing_date}
+            Please check the submission logs for details.
+            """
+        stripped_template = textwrap.dedent(template).strip()
+        return stripped_template.format(
+            log=submission_log_entry,
+            time=current_time.time(),
+            date=current_time.date(),
+        )
 
     def create_submission_log_entry(self, response_text, record):
 

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -58,6 +58,7 @@ class MtdVatIssueRequest(models.Model):
 
     @api.multi
     def json_command(self, command, module_name=None, record_id=None, api_tracker=None, timeout=3):
+        # TODO command not used?
         try:
             # TODO take record (with more descriptive name) as param instead
             #  of module_name and record_id.  Also we can't do anything without

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -264,7 +264,6 @@ class MtdVatIssueRequest(models.Model):
         )
 
     def create_submission_log_entry(self, response_text, record):
-
         return self.env['mtd_vat.vat_submission_logs'].create({
             'name': "{} - {}".format(record.date_from, record.date_to),
             'response_text': response_text,

--- a/account_mtd_vat/models/mtd_vat_issue_request.py
+++ b/account_mtd_vat/models/mtd_vat_issue_request.py
@@ -425,7 +425,7 @@ class MtdVatIssueRequest(models.Model):
             })
 
 
-    def display_view_returns(self, response=None, record=None):
+    def display_view_returns(self, response, record):
 
         response_logs = json.loads(response.text)
         record.period_key = response_logs['periodKey']

--- a/account_mtd_vat/models/mtd_vat_obligation_logs.py
+++ b/account_mtd_vat/models/mtd_vat_obligation_logs.py
@@ -20,3 +20,12 @@ class MtdVATObligationLogs(models.Model):
     received = fields.Char()
     company_id = fields.Many2one('res.company', string="Company", readonly=True)
     vrn = fields.Char(string="VAT Number")
+    have_sent_submission_successfully = fields.Boolean(
+        help="Whether Odoo thinks the submission has been sent"
+        # In face of at least the sandbox API failing to return the right
+        # status after submission
+    )
+
+    @api.multi
+    def is_fulfilled(self):
+        return self.status == 'F'

--- a/account_mtd_vat/models/mtd_vat_submission_logs.py
+++ b/account_mtd_vat/models/mtd_vat_submission_logs.py
@@ -29,6 +29,7 @@ class MtdVATSubmissionLogs(models.Model):
     payment_indicator = fields.Char(compute='_compute_response_fields')
     charge_ref_number = fields.Char(compute='_compute_response_fields')
     processing_date = fields.Datetime(compute='_compute_response_fields')
+    raw_processing_date = fields.Char(compute='_compute_response_fields')
     redirect_url = fields.Char()
     vat_due_sales_submit = fields.Float("1. VAT due in this period on sales and other outputs", (13, 2), readonly=True)
     vat_due_acquisitions_submit = fields.Float(
@@ -96,9 +97,10 @@ class MtdVATSubmissionLogs(models.Model):
         self.payment_indicator = parsed_response.get('paymentIndicator', False)
         self.charge_ref_number = \
             parsed_response.get('chargeRefNumber', 'No Data Found')
-        processing_date_str = parsed_response.get('processingDate', False)
+        self.raw_processing_date = parsed_response.get('processingDate', False)
         self.processing_date = \
-            processing_date_str and datetime_iso2odoo(processing_date_str)
+            self.raw_processing_date and datetime_iso2odoo(
+                self.raw_processing_date)
 
 
 def datetime_iso2odoo(iso_string):

--- a/account_mtd_vat/models/mtd_vat_submission_logs.py
+++ b/account_mtd_vat/models/mtd_vat_submission_logs.py
@@ -25,6 +25,7 @@ class MtdVATSubmissionLogs(models.Model):
     unique_number = fields.Char(
         string="HMRC Unique Number",
         compute='_compute_response_fields',
+        store=True,
     )
     payment_indicator = fields.Char(compute='_compute_response_fields')
     charge_ref_number = fields.Char(compute='_compute_response_fields')
@@ -73,7 +74,6 @@ class MtdVATSubmissionLogs(models.Model):
         ('agent', 'Agent')
     ])
     md5_integrity_value = fields.Char(string="Checksum", readonly=True)
-
 
     @api.multi
     def action_Detailed_submission_Log_view(self, *args):

--- a/account_mtd_vat/models/mtd_vat_submission_logs.py
+++ b/account_mtd_vat/models/mtd_vat_submission_logs.py
@@ -87,7 +87,6 @@ class MtdVATSubmissionLogs(models.Model):
              'domain': "[('unique_number', '=', '{}')]".format(self.unique_number)
          }
 
-
     @api.one
     @api.depends('response_text')
     def _compute_response_fields(self):
@@ -101,7 +100,6 @@ class MtdVATSubmissionLogs(models.Model):
         self.processing_date = \
             self.raw_processing_date and datetime_iso2odoo(
                 self.raw_processing_date)
-
 
 def datetime_iso2odoo(iso_string):
     datetime_obj = dateutil.parser.parse(iso_string)

--- a/account_mtd_vat/models/mtd_vat_submission_logs.py
+++ b/account_mtd_vat/models/mtd_vat_submission_logs.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
+import operator
+
+import dateutil.parser
 
 from openerp import models, fields, api
 
@@ -10,16 +14,21 @@ class MtdVATSubmissionLogs(models.Model):
     _name = 'mtd_vat.vat_submission_logs'
     _description = "Vat Submission Log"
 
+    response_text = fields.Text(
+        help="Actual string returned by HMRC API, hopefully in JSON")
     name = fields.Char(string="Period")
     submission_status = fields.Char()
     company_id = fields.Many2one('res.company', string="Company", readonly=True)
     vrn = fields.Char(string="VAT Number")
     start = fields.Date()
     end = fields.Date()
-    unique_number = fields.Char(string="HMRC Unique Number")
-    payment_indicator = fields.Char()
-    charge_ref_number = fields.Char()
-    processing_date = fields.Datetime()
+    unique_number = fields.Char(
+        string="HMRC Unique Number",
+        compute='_compute_response_fields',
+    )
+    payment_indicator = fields.Char(compute='_compute_response_fields')
+    charge_ref_number = fields.Char(compute='_compute_response_fields')
+    processing_date = fields.Datetime(compute='_compute_response_fields')
     redirect_url = fields.Char()
     vat_due_sales_submit = fields.Float("1. VAT due in this period on sales and other outputs", (13, 2), readonly=True)
     vat_due_acquisitions_submit = fields.Float(
@@ -76,3 +85,22 @@ class MtdVATSubmissionLogs(models.Model):
              'target': 'self',
              'domain': "[('unique_number', '=', '{}')]".format(self.unique_number)
          }
+
+
+    @api.one
+    @api.depends('response_text')
+    def _compute_response_fields(self):
+        response = self.response_text
+        parsed_response = json.loads(response) if response else dict()
+        self.unique_number = parsed_response.get('formBundleNumber', False)
+        self.payment_indicator = parsed_response.get('paymentIndicator', False)
+        self.charge_ref_number = \
+            parsed_response.get('chargeRefNumber', 'No Data Found')
+        processing_date_str = parsed_response.get('processingDate', False)
+        self.processing_date = \
+            processing_date_str and datetime_iso2odoo(processing_date_str)
+
+
+def datetime_iso2odoo(iso_string):
+    datetime_obj = dateutil.parser.parse(iso_string)
+    return fields.Datetime.to_string(datetime_obj)

--- a/account_mtd_vat/tests/__init__.py
+++ b/account_mtd_vat/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_chart_of_taxes
+from . import test_mtd_vat_submission_logs

--- a/account_mtd_vat/tests/test_mtd_vat_submission_logs.py
+++ b/account_mtd_vat/tests/test_mtd_vat_submission_logs.py
@@ -1,8 +1,10 @@
+import datetime
 import json
 
 from openerp.tests import common
 
 class GivenSimpleSubmissionLogEntry(common.TransactionCase):
+    """Unit tests (for now) of bits of submission log entry code"""
     def setUp(self):
         super(GivenSimpleSubmissionLogEntry, self).setUp()
         fake_response = json.dumps(self.faked_response())
@@ -10,8 +12,11 @@ class GivenSimpleSubmissionLogEntry(common.TransactionCase):
             self.env['mtd_vat.vat_submission_logs'].create(dict(
                 name='TEST LOG ENTRY',
                 response_text=fake_response,
+                start='2019-03-01',
+                end='2019-05-31',
             ))
         )
+        self.fake_now = datetime.datetime(2019, 6, 19, 9, 49, 30)
 
     def faked_response(self):
         self.skipTest("ABSTRACT: faked_response()")
@@ -39,6 +44,23 @@ class GivenSubmissionLogEntryWithFullResponse_Tests(
     def test_charge_ref_number(self):
         self.assertEqual(self.logentry.charge_ref_number, '4224'),
 
+    def test_raw_processing_date(self):
+        self.assertEqual(self.logentry.raw_processing_date,
+            '2112-12-21T13:24:38')
+
+    def test_success_message_format(self):
+        result = self.env['mtd_vat.issue_request']._success_message(
+            submission_log_entry=self.logentry,
+            current_time=self.fake_now,
+        )
+        self.assertIn("Date 2019-06-19", result)
+        self.assertIn("Time 09:49:30", result)
+        self.assertIn("Period: 2019-03-01 - 2019-05-31", result)
+        self.assertIn("Unique number: 42", result)
+        self.assertIn("Payment indicator: INDIC8", result)
+        self.assertIn("Charge ref number: 4224", result)
+        self.assertIn("Processing date: 2112-12-21T13:24:38", result)
+
 
 class GivenSubmissionLogEntryWithEmptyResponse_Tests(
         GivenSimpleSubmissionLogEntry):
@@ -51,3 +73,11 @@ class GivenSubmissionLogEntryWithEmptyResponse_Tests(
 
     def test_charge_ref_number_is_humanised_missing_message(self):
         self.assertEqual(self.logentry.charge_ref_number, "No Data Found")
+
+    def test_success_message_method_does_not_crash(self):
+        # It's going to look weird and ugly with all those 'false's everywhere
+        # but it should at least not crash.
+        self.env['mtd_vat.issue_request']._success_message(
+            submission_log_entry=self.logentry,
+            current_time=self.fake_now,
+        )

--- a/account_mtd_vat/tests/test_mtd_vat_submission_logs.py
+++ b/account_mtd_vat/tests/test_mtd_vat_submission_logs.py
@@ -1,0 +1,53 @@
+import json
+
+from openerp.tests import common
+
+class GivenSimpleSubmissionLogEntry(common.TransactionCase):
+    def setUp(self):
+        super(GivenSimpleSubmissionLogEntry, self).setUp()
+        fake_response = json.dumps(self.faked_response())
+        self.logentry = (
+            self.env['mtd_vat.vat_submission_logs'].create(dict(
+                name='TEST LOG ENTRY',
+                response_text=fake_response,
+            ))
+        )
+
+    def faked_response(self):
+        self.skipTest("ABSTRACT: faked_response()")
+
+
+class GivenSubmissionLogEntryWithFullResponse_Tests(
+        GivenSimpleSubmissionLogEntry):
+    def faked_response(self):
+        return {
+            'formBundleNumber': '42',
+            'paymentIndicator': 'INDIC8',
+            'processingDate': '2112-12-21T13:24:38',
+            'chargeRefNumber': '4224',
+        }
+
+    def test_unique_number(self):
+        self.assertEqual(self.logentry.unique_number, '42')
+
+    def test_payment_indicator(self):
+        self.assertEqual(self.logentry.payment_indicator, 'INDIC8')
+
+    def test_processing_date(self):
+        self.assertEqual(self.logentry.processing_date, '2112-12-21 13:24:38')
+
+    def test_charge_ref_number(self):
+        self.assertEqual(self.logentry.charge_ref_number, '4224'),
+
+
+class GivenSubmissionLogEntryWithEmptyResponse_Tests(
+        GivenSimpleSubmissionLogEntry):
+    def faked_response(self):
+        return dict()
+
+    def test_expected_to_be_false_if_missing(self):
+        for field in ['unique_number', 'payment_indicator', 'processing_date']:
+            self.assertFalse(getattr(self.logentry, field), field)
+
+    def test_charge_ref_number_is_humanised_missing_message(self):
+        self.assertEqual(self.logentry.charge_ref_number, "No Data Found")

--- a/account_mtd_vat/views/mtd_vat_endpoint_view.xml
+++ b/account_mtd_vat/views/mtd_vat_endpoint_view.xml
@@ -37,9 +37,11 @@
                             <field name="select_vat_obligation"
                                 string="Select VAT Obligation"
                                 attrs="{'invisible':[('name', 'not in', ['Submit a VAT Return', 'View VAT Returns'])]}"
-                                domain="([('company_id', '=', obligation_company)])"
+                                domain="([
+                                    ('company_id', '=', obligation_company),
+                                    ('status', '=', obligation_status),
+                                ])"
                                 options="{'no_quick_create': True, 'no_create_edit' : True}"/>
-                            <!--('status', '=', obligation_status), -->
                             <!--<field name="retrieve_vat_obligation_first"
                                    string="Please retrive VAT obligation here"
                                 attrs="{'invisible':[('name', '!=', 'Submit VAT Returns')]}"/>-->

--- a/account_mtd_vat/views/mtd_vat_endpoint_view.xml
+++ b/account_mtd_vat/views/mtd_vat_endpoint_view.xml
@@ -37,10 +37,9 @@
                             <field name="select_vat_obligation"
                                 string="Select VAT Obligation"
                                 attrs="{'invisible':[('name', 'not in', ['Submit a VAT Return', 'View VAT Returns'])]}"
-                                domain="([
+                                domain="[
                                     ('company_id', '=', obligation_company),
-                                    ('status', '=', obligation_status),
-                                ])"
+                                ]"
                                 options="{'no_quick_create': True, 'no_create_edit' : True}"/>
                             <!--<field name="retrieve_vat_obligation_first"
                                    string="Please retrive VAT obligation here"


### PR DESCRIPTION
Release candidate for 8.0.0.10

* Be tolerant of HMRC not returning some fields in VAT return submission response
* Store full JSON response in submission log, and compute displayed fields from there
* Show user error if they try to re-submit an obligation we have already had a success back from HMRC for, or if our currently-stored status for that obligation is Fulfilled ('F').  #26 will cover automatically re-syncing with HMRC just before that check in case it changed since last manual sync.
* Make handling of more than one active auth request token a little bit more user friendly - it was 500-ing.

Note that point (4) is covered by issue #27 and deferred until later