### PR TITLE
[T15219 w2] Remove the search on api_id

### DIFF
--- a/account_mtd_vat/models/mtd_vat_endpoint.py
+++ b/account_mtd_vat/models/mtd_vat_endpoint.py
@@ -489,7 +489,6 @@ class MtdVATEndpoints(models.Model):
                 "We have no access token and refresh token found"
             )
             authorisation_tracker = self.env['mtd.api_request_tracker'].search([
-                ('api_id', '=', self.api_id.id),
                 ('closed', '=', False)
             ])
         create_date = fields.Datetime.from_string(authorisation_tracker.create_date)


### PR DESCRIPTION
This is so that we don't get into the 500 server error as When returned
to the server we do not have any means of knowing which api was used to
create the request. Originally the design was to allow one request tracker
per module but this can cause 500 server error as we can have two open request
trackers.